### PR TITLE
Allow to use docker as the virtualization tool 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ arch-linux: dist-dir
 	cp -r distros/archlinux/. ./shutorial-$(VERSION)/
 	cd shutorial-$(VERSION) ; makepkg -g >> PKGBUILD; makepkg -s; mv *.pkg.tar.zst ../
 
+docker: all
+	docker build -t shutorial distros/Docker/.
+	cp distros/Docker/shutorial.sh shutorial
+	chmod +x shutorial
+	for f in `find site -name '*setup.sh'`; do echo "Changing location of shtrl-check in $$f"; sed -i 's/\/usr\/lib\/shutorial\/bin/\/shutorial\/bin/' $$f; chmod +rx $$f; done
+
 install:
 	mkdir -p $(DESTDIR)/var/www/html/shutorial
 	cp -r site/* $(DESTDIR)/var/www/html/shutorial
@@ -59,4 +65,4 @@ clean:
 	rm -rf site shutorial-$(VERSION) shutorial_$(VERSION)*
 	find -name __pycache__ | xargs rm -rf
 	find -name '*~' | xargs rm -rf
-
+	rm shutorial

--- a/distros/Docker/Dockerfile
+++ b/distros/Docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:latest
+
+USER root
+
+# Find the missing commands used in the exercices
+RUN apt-get update --fix-missing
+RUN apt-get -y install procps man-db ncal tree less console-data
+RUN apt-get -y install emacs
+RUN apt-get -y install nano
+RUN apt-get -y install vim
+RUN apt-get -y install locate
+RUN apt-get -y install sharutils
+
+# Setup a nice shutorial environnment
+RUN useradd SHuToRiaL
+RUN mkdir /home/SHuToRiaL
+RUN chown SHuToRiaL /home/SHuToRiaL
+# Required to have shtrl-check executable working
+#   without that, the script couldn't be created in a nice place other than Home
+RUN mkdir /shutorial
+RUN mkdir /shutorial/bin
+RUN chown SHuToRiaL /shutorial/bin
+
+# Move the docker to the created environment
+USER SHuToRiaL
+WORKDIR /home/SHuToRiaL

--- a/distros/Docker/shutorial.sh
+++ b/distros/Docker/shutorial.sh
@@ -32,12 +32,13 @@ run)
         url="$PWD/site/usage/$exo/goal.html"
     fi
     firefox "$url" 2>/dev/null
-
+    echo ''
+    echo 'Please open $$url in your browser if it was not automatically done (use Ctrl-Insert in place of Ctrl-C if you need to copy this URL).'
+    echo 'When you are done, simply press Ctrl-D to exit the shutorial.'
+    echo ''
     docker run -v ./site/usage/$exo:/exo -e LANG=C.UTF-8 -it shutorial sh -c "if test -f /exo/setup.sh; then /bin/bash /exo/setup.sh; fi && export PATH='/shutorial/bin:$PATH' && /bin/bash"
 
 
-
- 
     echo "The session is terminating. Cleaning up."
     ;;
 
@@ -49,6 +50,7 @@ prune-sessions)
     echo "Usage:" >&2
     echo " shutorial list             # Print the list of existing exercises" >&2
     echo " shutorial run [exercise]   # Run the specified exercise" >&2
+    # Actually, no need to prune anything with docker
     echo " shutorial prune-sessions   # End all shutorial sessions (warning, ongoing sessions will be terminated too)" >&2
     exit 1
     ;;

--- a/distros/Docker/shutorial.sh
+++ b/distros/Docker/shutorial.sh
@@ -1,0 +1,55 @@
+#! /bin/sh
+
+case "$1" in
+list)
+    echo "Here is the list of existing exercises:"
+    sed 's/^/  /' ./exo/usage/exercises.list
+    echo
+    echo "For example, to start the first exercise from this list, simply type:"
+    echo "  shutorial run intro"
+    exit 0
+    ;;
+
+run)
+    exo=$2
+    if [ -z "$exo" -o ! -e "./exo/usage/exercises.list" ]; then
+        echo "Please select an exercise from the following list:"
+        sed 's/^/  /' ./exo/usage/exercises.list
+        echo
+        echo "For example, to start the first exercise from this list, simply type:"
+        echo "  shutorial run intro"
+        exit 1
+    fi
+
+    user=$(id -un)
+
+    echo "Launching exercice $exo"
+    
+    # Tell the user what to do on login
+    if pidof -q lighttpd; then
+        url="http://localhost/shutorial/usage/$exo/goal.html"
+    else
+        url="$PWD/site/usage/$exo/goal.html"
+    fi
+    firefox "$url" 2>/dev/null
+
+    docker run -v ./site/usage/$exo:/exo -e LANG=C.UTF-8 -it shutorial sh -c "if test -f /exo/setup.sh; then /bin/bash /exo/setup.sh; fi && export PATH='/shutorial/bin:$PATH' && /bin/bash"
+
+
+
+ 
+    echo "The session is terminating. Cleaning up."
+    ;;
+
+prune-sessions)
+    echo "Ending all shutorial sessions..."
+    echo "Done."
+    ;;
+*)
+    echo "Usage:" >&2
+    echo " shutorial list             # Print the list of existing exercises" >&2
+    echo " shutorial run [exercise]   # Run the specified exercise" >&2
+    echo " shutorial prune-sessions   # End all shutorial sessions (warning, ongoing sessions will be terminated too)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This little MR brings all that is required to use shutorial inside a docker instead of chroot.

To use it, simply make docker. It compiles all the exercises inside the site directory and ensures the ./shutorial script
launches docker with the required parameters.